### PR TITLE
Exclude docs from release archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+.gitattributes export-ignore
+README.md export-ignore
+preview.png export-ignore


### PR DESCRIPTION
This will make the release archives smaller.